### PR TITLE
Generate controllers with neat status codes

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -31,7 +31,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     if @<%= orm_instance.save %>
       redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -40,7 +40,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
       redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
### Summary

For RESTful APIs, it is beneficial to return appropriate status codes since developers, for example, detect the frequency of validation errors from the status codes through web server logs, Google Analytics, etc.
This commit makes `rails generate` put `422 Unprocessable Entity` on create and update actions.